### PR TITLE
Add configurable target language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Cast Translator
+
+Translate Farcaster casts using Google Translate. You can choose the language you want casts translated into via a dropdown in the miniapp. The selected language is stored in `localStorage` so your preference is remembered on future visits.
+
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.


### PR DESCRIPTION
## Summary
- allow user to choose a target language and remember it in `localStorage`
- document the Cast Translator app in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684578d297a8832b866b619458bc83a2